### PR TITLE
removing unneeded config

### DIFF
--- a/templates/app-protect-security-policy.j2
+++ b/templates/app-protect-security-policy.j2
@@ -3,15 +3,4 @@
     "template": { "name": "POLICY_TEMPLATE_NGINX_BASE" },
     "applicationLanguage": "utf-8",
     "enforcementMode": "{{ security_policy_enforcement_mode }}"
-{% if app_protect_install_threat_campaigns %},
-    "blocking-settings": {
-        "violations": [
-            {
-                "name": "VIOL_THREAT_CAMPAIGN",
-                "alarm": true,
-                "block": true
-            }
-        ]
-    }
-{% endif %}
 }


### PR DESCRIPTION
since threat campaigns violations are already enabled in the default policy, removing the redundant config